### PR TITLE
gui/editwidget: Fix Qt exception due to argument type

### DIFF
--- a/awlsim/gui/editwidget.py
+++ b/awlsim/gui/editwidget.py
@@ -836,7 +836,7 @@ class EditWidget(SourceCodeEdit):
 		p.setPen(Qt.black)
 
 		for lineNr, yOffset in self.__eachVisibleLine():
-			p.drawText(-5, yOffset,
+			p.drawText(-5, int(yOffset),
 				   self.lineNumWidget.width(),
 				   self.__charHeight,
 				   Qt.AlignRight,


### PR DESCRIPTION
The argument must be an integer instead of a float, to prevent the following exception from happening:

	Traceback (most recent call last):
	  File ".../awlsim/awlsim/gui/editwidget.py", line 839, in __repaintLineNumWidget
	    p.drawText(-5, yOffset,
	TypeError: arguments did not match any overloaded call:
	  drawText(self, Union[QPointF, QPoint], str): argument 1 has unexpected type 'int'
	  drawText(self, QRectF, int, str): argument 1 has unexpected type 'int'
	  drawText(self, QRect, int, str): argument 1 has unexpected type 'int'
	  drawText(self, QRectF, str, option: QTextOption = QTextOption()): argument 1 has unexpected type 'int'
	  drawText(self, QPoint, str): argument 1 has unexpected type 'int'
	  drawText(self, int, int, int, int, int, str): argument 2 has unexpected type 'float'
	  drawText(self, int, int, str): argument 2 has unexpected type 'float'