### PR TITLE
SFC 24 TEST_DB: add DB existence check

### DIFF
--- a/awlsim/core/systemblocks/system_sfc.pxd.in
+++ b/awlsim/core/systemblocks/system_sfc.pxd.in
@@ -4,6 +4,7 @@ from awlsim.core.systemblocks.system_sfc_m3 cimport *
 from awlsim.core.systemblocks.system_sfc_m2 cimport *
 from awlsim.core.systemblocks.system_sfc_m1 cimport *
 from awlsim.core.systemblocks.system_sfc_21 cimport *
+from awlsim.core.systemblocks.system_sfc_24 cimport *
 from awlsim.core.systemblocks.system_sfc_46 cimport *
 from awlsim.core.systemblocks.system_sfc_47 cimport *
 from awlsim.core.systemblocks.system_sfc_64 cimport *

--- a/awlsim/core/systemblocks/system_sfc.py
+++ b/awlsim/core/systemblocks/system_sfc.py
@@ -28,6 +28,7 @@ from awlsim.core.systemblocks.system_sfc_m3 import * #+cimport
 from awlsim.core.systemblocks.system_sfc_m2 import * #+cimport
 from awlsim.core.systemblocks.system_sfc_m1 import * #+cimport
 from awlsim.core.systemblocks.system_sfc_21 import * #+cimport
+from awlsim.core.systemblocks.system_sfc_24 import * #+cimport
 from awlsim.core.systemblocks.system_sfc_46 import * #+cimport
 from awlsim.core.systemblocks.system_sfc_47 import * #+cimport
 from awlsim.core.systemblocks.system_sfc_64 import * #+cimport
@@ -43,6 +44,7 @@ _SFC_table = { #+cdef-dict
 	-1	: SFCm1,	# __SFC_NOP
 
 	21	: SFC21,	# FILL
+	24	: SFC24,	# TEST_DB
 	46	: SFC46,	# STP
 	47	: SFC47,	# WAIT
 	64	: SFC64,	# TIME_TCK

--- a/awlsim/core/systemblocks/system_sfc_24.pxd.in
+++ b/awlsim/core/systemblocks/system_sfc_24.pxd.in
@@ -1,0 +1,5 @@
+from awlsim.common.cython_support cimport *
+from awlsim.core.systemblocks.systemblocks cimport *
+
+cdef class SFC24(SFC):
+	cpdef run(self)

--- a/awlsim/core/systemblocks/system_sfc_24.py
+++ b/awlsim/core/systemblocks/system_sfc_24.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# AWL simulator - SFCs
+#
+# Copyright 2016-2018 Michael Buesch <m@bues.ch>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from __future__ import division, absolute_import, print_function, unicode_literals
+#from awlsim.common.cython_support cimport * #@cy
+from awlsim.common.compat import *
+
+from awlsim.common.exceptions import *
+from awlsim.common.util import *
+
+from awlsim.core.systemblocks.systemblocks import * #+cimport
+from awlsim.core.blockinterface import *
+from awlsim.core.datablocks import * #+cimport
+from awlsim.core.memory import * #+cimport
+
+
+class SFC24(SFC): #+cdef
+	name = (24, "TEST_DB", "test data block")
+
+	interfaceFields = {
+		BlockInterfaceField.FTYPE_IN	: (
+			BlockInterfaceField(name="DB_NUMBER", dataType="WORD"),
+		),
+		BlockInterfaceField.FTYPE_OUT	: (
+			BlockInterfaceField(name="RET_VAL", dataType="INT"),
+			BlockInterfaceField(name="DB_LENGTH", dataType="WORD"),
+			BlockInterfaceField(name="WRITE_PROT", dataType="BOOL"),
+		),
+	}
+
+	def run(self): #+cpdef
+#@cy		cdef S7StatusWord s
+#@cy		cdef uint32_t dbNr
+
+		s = self.cpu.statusWord
+
+		dbNr = AwlMemoryObject_asScalar(
+			self.fetchInterfaceFieldByName("DB_NUMBER"))
+
+		if dbNr == 0:
+			# 0x80A1: DB_NUMBER is 0 or > max permissible.
+			self.storeInterfaceFieldByName("RET_VAL",
+				make_AwlMemoryObject_fromScalar(0x80A1, 16))
+			self.storeInterfaceFieldByName("DB_LENGTH",
+				make_AwlMemoryObject_fromScalar(0, 16))
+			self.storeInterfaceFieldByName("WRITE_PROT",
+				make_AwlMemoryObject_fromScalar(0, 1))
+			s.BIE = 0
+			return
+
+		db = self.cpu.getDB(dbNr)
+		if db is None or db.index != dbNr:
+			# 0x80B1: DB with the specified number does not exist.
+			self.storeInterfaceFieldByName("RET_VAL",
+				make_AwlMemoryObject_fromScalar(0x80B1, 16))
+			self.storeInterfaceFieldByName("DB_LENGTH",
+				make_AwlMemoryObject_fromScalar(0, 16))
+			self.storeInterfaceFieldByName("WRITE_PROT",
+				make_AwlMemoryObject_fromScalar(0, 1))
+			s.BIE = 0
+			return
+
+		dbLen = db.struct.getSize() & 0xFFFF
+		writeProt = 0 if (db.permissions & db.PERM_WRITE) else 1
+
+		self.storeInterfaceFieldByName("RET_VAL",
+			make_AwlMemoryObject_fromScalar(0, 16))
+		self.storeInterfaceFieldByName("DB_LENGTH",
+			make_AwlMemoryObject_fromScalar(dbLen, 16))
+		self.storeInterfaceFieldByName("WRITE_PROT",
+			make_AwlMemoryObject_fromScalar(writeProt, 1))
+		s.BIE = 1

--- a/tests/tc500_systemblocks/sfc/sfc24.awl
+++ b/tests/tc500_systemblocks/sfc/sfc24.awl
@@ -1,0 +1,65 @@
+DATA_BLOCK DB 1
+STRUCT
+	W1	: WORD;
+	W2	: WORD;
+	W3	: WORD;
+END_STRUCT;
+BEGIN
+END_DATA_BLOCK
+
+
+ORGANIZATION_BLOCK OB 1
+	VAR_TEMP
+		RET_TMP		: INT;
+		LEN_TMP		: WORD;
+		WP_TMP		: BOOL;
+	END_VAR
+BEGIN
+	// Test SFC 24: TEST_DB
+	// Returns DB length and write-protect status.
+	// RET_VAL = 0x0000 OK, 0x80A1 DB_NUMBER 0/out-of-range, 0x80B1 DB
+	// not loaded, 0x80B2 DB UNLINKED (not modeled by awlsim).
+
+
+	// Case 1: DB 1 exists with three WORDs (6 bytes) - expect OK
+	CALL		SFC 24 (
+		DB_NUMBER	:= W#16#0001,
+		RET_VAL		:= #RET_TMP,
+		DB_LENGTH	:= #LEN_TMP,
+		WRITE_PROT	:= #WP_TMP,
+	)
+	__ASSERT==	__STW BIE,	1
+	L		#RET_TMP
+	__ASSERT==	__ACCU 1,	W#16#0000
+	L		#LEN_TMP
+	__ASSERT==	__ACCU 1,	W#16#0006
+	U		#WP_TMP
+	__ASSERT==	__STW VKE,	0
+
+
+	// Case 2: DB_NUMBER = 0 - expect 0x80A1
+	CALL		SFC 24 (
+		DB_NUMBER	:= W#16#0000,
+		RET_VAL		:= #RET_TMP,
+		DB_LENGTH	:= #LEN_TMP,
+		WRITE_PROT	:= #WP_TMP,
+	)
+	__ASSERT==	__STW BIE,	0
+	L		#RET_TMP
+	__ASSERT==	__ACCU 1,	W#16#80A1
+
+
+	// Case 3: DB 99 not loaded - expect 0x80B1
+	CALL		SFC 24 (
+		DB_NUMBER	:= W#16#0063,
+		RET_VAL		:= #RET_TMP,
+		DB_LENGTH	:= #LEN_TMP,
+		WRITE_PROT	:= #WP_TMP,
+	)
+	__ASSERT==	__STW BIE,	0
+	L		#RET_TMP
+	__ASSERT==	__ACCU 1,	W#16#80B1
+
+
+	CALL SFC 46 // STOP CPU
+END_ORGANIZATION_BLOCK


### PR DESCRIPTION
Adds SFC 24 TEST_DB support and a regression fixture.

Validated locally:
- CRLF-aware diff-check for the AWL fixture
- ./tests/run.sh -i python3 tests/tc500_systemblocks/sfc/sfc24.awl

Note: the AWL fixture intentionally keeps CRLF line endings required by the test runner.

Rollback: close the PR before merge, or revert the commit after merge.